### PR TITLE
support for bindings like this- name='kid.name'

### DIFF
--- a/angular_bind_polymer.js
+++ b/angular_bind_polymer.js
@@ -7,36 +7,52 @@ directive('bindPolymer', function($q, $timeout) {
       for (var prop in attrs.$attr) {
         if (prop != 'bindPolymer') {
           var _attr = attrs.$attr[prop];
-          var _match = element.attr(_attr).match(/\{\{\s*(\w+)\s*\}\}/);
+          var _match = element.attr(_attr).match(/\{\{\s*(\w+\.)*\w+\s*\}\}/);
           if (_match) {
-            attrMap[_attr] = _match[1];
+              var tmp = (_match[0].replace(/{{|}}/g, "")).trim();
+              attrMap[_attr] = tmp;
           }
         }
       }
 
       // Always get updated Polymer element
       function polymer() {
-        var all = document.querySelectorAll(element[0].nodeName);
-        for (var i=0; i<all.length; i++) {
-          if (all[i] == element[0]) return all[i];
-          if (all[i].impl == element[0]) return all[i];
-        }
+        return element.parent().find(element[0].nodeName)[0];
       }
 
-      // When Polymer sees a change to the bound variable,
-      // $apply / $digest the changes here in Angular
-      var observer = new MutationObserver(function() {
-        scope.$apply();
-      });
-      observer.observe(polymer(), {attributes: true});
-      for (var _attr in attrMap) {
-        scope.$watch(
-          function() {return element.attr(_attr);},
-          function(value) {
-            scope[attrMap[_attr]] = value;
-          }
-        );
+      // Helper to wait for Polymer to expose the observe property
+      function onPolymerReady() {
+        var deferred = $q.defer();
+
+        function _checkForObserve() {
+          polymer().observe ?
+            deferred.resolve() :
+            $timeout(_checkForObserve, 10);
+        }
+        _checkForObserve();
+
+        return deferred.promise;
       }
+
+      // When Polymer is ready, establish the bound variable watch
+      onPolymerReady().
+        then(function(){
+          // When Polymer sees a change to the bound variable,
+          // $apply / $digest the changes here in Angular
+          var observer = new MutationObserver(function() {
+            scope.$apply();
+          });
+          observer.observe(polymer(), {attributes: true});
+
+          for (var _attr in attrMap) {
+            scope.$watch(
+              function() {return element.attr(_attr);},
+              function(value) {
+                eval('scope.' + attrMap[_attr].toString() + '= value');
+              }
+            );
+          }
+        });
     }
   };
 });


### PR DESCRIPTION
I have made some tweaks to make this library to be able not only support binding like this: `<span>{{name}}</span>` but also like this: `<span>{{kid.name}}</span>`  (the kid name is a primitive variable). For now it is nor working for objects binding.  
