### PR TITLE
Using directive compile #14

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,18 +22,26 @@
     <link rel="import" href="test/x-double.html">
   </head>
   <body ng-app="smokeTest">
-    <div class="container">
+    <div class="container" ng-init="showForm = true">
       <h1>Smoke Test: angular-bind-polymer</h1>
 
+      <label>
+        <input type="checkbox" ng-model="showForm">
+        Hide the polymer element using <code>ngIf</code>. Currently <span ng-bind="showForm ? 'hided' : 'shown'"></span>
+      </label>
+
+      <div ng-if="showForm">
       <p>
         in:<br>
-        <input type=text value="6" ng-model=in>
+        <input type=text value="6" ng-model="in">
+        <pre ng-bind="in"></pre>
       </p>
       <p>
         out:
         <pre ng-bind="doubled"></pre>
       </p>
-      <x-double bind-polymer in="{{in}}" out="{{doubled}}"></x-double>
+        <x-double bind-polymer in="{{in}}" out="{{doubled}}" disabled test="test"></x-double>
+      </div>
     </div>
   </body>
 </html>


### PR DESCRIPTION
This PR fixes the issue that the `bind-polymer` directive stopped working after the initial link ( #14 ).
This was caused because in the second link, the attribute didn't have the value with the curly braces notation anymore.
To fix this, we retrieve the bind expressions in the compile phase rather than the linking phase.

In this commit I also take the refactorings of @heavysixer (pull request #12) into account.
The watcher is indeed unneeded and it's logic has moved to the `MutationObserver`.

Also I got rid of the own implementation to traverse expressions by using the Angular $parser.
This returns both a getter and setter used in the MutationObserver.
This probably fixes issue #10 as well.

The example is changed to show that `ng-if` now works.